### PR TITLE
Graceful stop

### DIFF
--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -111,6 +111,8 @@ func runBrowser(cfg browserConfig, readyCh, stopCh chan struct{}) {
 	if err := chromedp.Run(ctx,
 		// chromedp.EmulateViewport(1706, 960, chromedp.EmulateScale(1.5)),
 		chromedp.Navigate(cfg.siteURL),
+		chromedp.WaitVisible(`.get-app__continue`, chromedp.ByQuery),
+		chromedp.Click(`.get-app__continue`, chromedp.ByQuery),
 		chromedp.WaitVisible(`#saveSetting`, chromedp.ByID),
 		chromedp.SendKeys(`#input_loginId`, cfg.username, chromedp.ByID),
 		chromedp.SendKeys(`#input_password-input`, cfg.password, chromedp.ByID),

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -83,14 +83,8 @@ func runBrowser(cfg browserConfig, readyCh, stopCh chan struct{}) {
 		// chromedp.Flag("ignore-certificate-errors", true),
 	}
 
-	allocCtx, cancelAllocCtx := chromedp.NewExecAllocator(context.Background(), opts...)
-	ctx, cancelCtx := chromedp.NewContext(allocCtx)
-
-	go func() {
-		<-stopCh
-		cancelCtx()
-		cancelAllocCtx()
-	}()
+	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)
+	ctx, _ := chromedp.NewContext(allocCtx)
 
 	chromedp.ListenTarget(ctx, func(ev interface{}) {
 		switch ev := ev.(type) {
@@ -127,6 +121,24 @@ func runBrowser(cfg browserConfig, readyCh, stopCh chan struct{}) {
 	); err != nil {
 		log.Printf(err.Error())
 	}
+
+	<-stopCh
+
+	log.Printf("stop received, shutting down browser")
+
+	if err := chromedp.Run(ctx,
+		chromedp.EvaluateAsDevTools("window.callsClient.disconnect();", nil),
+	); err != nil {
+		log.Printf(err.Error())
+	}
+
+	tctx, cancelCtx := context.WithTimeout(ctx, 10*time.Second)
+	// graceful cancel
+	if err := chromedp.Cancel(tctx); err != nil {
+		log.Printf(err.Error())
+	}
+	cancelCtx()
+	log.Printf("browser was shutdown")
 }
 
 func runRecorder(dst string) (*exec.Cmd, error) {


### PR DESCRIPTION
#### Summary

I noticed that the calls recorder was stuck for a few seconds (until server timeout). It's likely the browser instance isn't closed as expected, and not firing the `beforeunload` window event so added some code to explicitly disconnect from the call prior to exit.